### PR TITLE
handle case when server response with non-200 code

### DIFF
--- a/src/marketdata/download_md.sh
+++ b/src/marketdata/download_md.sh
@@ -24,6 +24,9 @@ function download {
       echo 'invalid token'
       exit 1
   fi
+#В случае другой ошибки - просто напишем ее в консоль и выйдем
+  echo "unspecified error with code: ${response_code}"
+  exit 1
 }
 
 while read -r figi; do


### PR DESCRIPTION
I got an error 404 for my curl-request, and still received exit_code 0 from script, which is really confusing:

```
23:32:21 sild@airhome:~/tink_script$ ./download.sh
downloading AAPL for year 2022
23:32:24 sild@airhome:~/tink_script$ echo $?
0
23:35:11 sild@airhome:~/tink_script$ curl -s --location "https://invest-public-api.tinkoff.ru/history-data?figi=AAPL&year=2022" -H "Authorization: Bearer ${TINKOFF_READ_TOKEN}" -o "APPL_2023.zip" -w '%{http_code}'
404
23:35:13 sild@airhome:~/tink_script$ echo $?
0
23:35:16 sild@airhome:~/tink_script$
```

Handled that case by more simple way.

Then I found out that mean `instrument not found`:

```
< HTTP/2 404
< code: 50002
< message: instrument not found
< x-tracking-id: 638146a22c912d30ae92adabdc3cc9f0
< content-length: 0
< x-envoy-upstream-service-time: 13
< date: Fri, 25 Nov 2022 22:50:10 GMT
< server: envoy
< x-ratelimit-limit: 30, 30;w=60
< x-ratelimit-remaining: 29
< x-ratelimit-reset: 50
```

But it's better to have some general handler for error cases.

Also I got error 400 (`date is invalid`) which I suppose is also possible while working with different time zones

