### PR TITLE
fix default scenario for download.sh

### DIFF
--- a/src/marketdata/download_md.sh
+++ b/src/marketdata/download_md.sh
@@ -24,9 +24,14 @@ function download {
       echo 'invalid token'
       exit 1
   fi
-#В случае другой ошибки - просто напишем ее в консоль и выйдем
-  echo "unspecified error with code: ${response_code}"
-  exit 1
+
+  if [ "$response_code" = "404" ]; then
+      echo "data not found for figi=${figi}, year=${year}, skipped"
+  elif [ "$response_code" != "200" ]; then
+      #В случае другой ошибки - просто напишем ее в консоль и выйдем
+      echo "unspecified error with code: ${response_code}"
+      exit 1
+  fi
 }
 
 while read -r figi; do


### PR DESCRIPTION
Fix default scenario ( run `git clone && ./src/marketdata/download_md.sh` )

Was broken by me in https://github.com/Tinkoff/investAPI/pull/309

Now it's fine:

```
02:49:30 localhost:~/investAPI/src/marketdata$ ./download_md.sh
downloading BBG00T22WKV5 for year 2022
downloading BBG00T22WKV5 for year 2021
downloading BBG00T22WKV5 for year 2020
downloading BBG00T22WKV5 for year 2019
data not found for figi=BBG00T22WKV5, year=2019, skipped
downloading BBG00R05JT04 for year 2022
downloading BBG00R05JT04 for year 2021
downloading BBG00R05JT04 for year 2020
```